### PR TITLE
Enable contact form with service selection

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,20 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name    = $_POST['name']    ?? '';
+    $email   = $_POST['email']   ?? '';
+    $phone   = $_POST['phone']   ?? '';
+    $service = $_POST['service'] ?? '';
+    $details = $_POST['details'] ?? '';
+
+    $to      = 'contact@example.com'; // Replace with real destination
+    $subject = 'New contact request';
+    $message = "Name: $name\nEmail: $email\nPhone: $phone\nService: $service\nDetails: $details";
+    $headers = "From: $email";
+
+    mail($to, $subject, $message, $headers);
+    echo 'Message sent';
+} else {
+    http_response_code(405);
+    echo 'Method not allowed';
+}
+

--- a/index.html
+++ b/index.html
@@ -71,37 +71,21 @@
 </section>
 
 
-<!--
-<section id="services">
-    services
-</section>
-
-
-<section id="contact"> 
+<section id="contact">
     <div class="formulario contenedor">
         <div class="formContenedor">
-            <form action="" method="">
+            <form id="contactForm" action="functions.php" method="POST">
                 <input type="text" id="name" name="name" placeholder="Name*" required>
                 <input type="email" id="email" name="email" placeholder="Mail*" required>
                 <input type="tel" id="phone" name="phone" placeholder="Phone*" required>
-                <input type="text" id="service" name="service" placeholder="Services" required>
+                <input type="hidden" id="service" name="service">
                 <textarea id="details" name="details" rows="8" placeholder="Message"></textarea>
-                <label for="cars">Choose a car:</label>
-
-                <select name="lenguajes" id="lang">
-                    <option value="javascript">JavaScript</option>
-                    <option value="php">PHP</option>
-                    <option value="java">Java</option>
-                    <option value="golang">Golang</option>
-                    <option value="python">Python</option>
-                    <option value="c#">C#</option>
-                    <option value="C++">C++</option>
-                    <option value="erlang">Erlang</option>
+                <button type="submit">Send</button>
             </form>
-        </div>  
+        </div>
     </div>
 </section>
--->
+
 
 
 <script type="module" src="menu.js"></script>

--- a/slider5.js
+++ b/slider5.js
@@ -19,6 +19,14 @@ document.addEventListener('DOMContentLoaded', () => {
         <div style="width: 50px;"></div>
       </div>
     `;
+    servicio.addEventListener('click', () => {
+      const serviceInput = document.getElementById('service');
+      if (serviceInput) serviceInput.value = title;
+      const contactSection = document.getElementById('contact');
+      if (contactSection) {
+        contactSection.scrollIntoView({ behavior: 'smooth' });
+      }
+    });
     container.appendChild(servicio);
   });
 


### PR DESCRIPTION
## Summary
- Reactivate contact form and add hidden field to capture chosen service
- Preselect service when clicking a slider card and scroll to contact form
- Submit contact form via PHP backend including service name

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce411bb483298611cdb2e836a0c4