### PR TITLE
Add basic HTML document structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <link rel=stylesheet type="text/css" href="style2.css">
-    <link rel=stylesheet type="text/css" href="animations.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" type="text/css" href="style2.css">
+    <link rel="stylesheet" type="text/css" href="animations.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
 
 </head>
 
+<body>
 
 <section id="header" class="seccionActiva">
     <div class="headerCont">
@@ -107,6 +112,5 @@
 <script type="module" src="menu.js"></script>
 <script type="module" src="slider5.js?v=1.0.3"></script>
 
-
-
-
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add missing DOCTYPE and html skeleton to `index.html`
- include charset and viewport meta tags for responsiveness and quote stylesheet links
- wrap page content in proper `<body>` and close HTML tags

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce3d76d08329ab2993b9f70b6dd2