### PR TITLE
Mejoras responsivas en servicios y carrusel

### DIFF
--- a/slider5.js
+++ b/slider5.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // 2) Variables del carrusel
   const items        = document.querySelectorAll('.itemCarrusel');
   const totalItems   = items.length;
-  const itemsVisibles= 3;
+  const itemsVisibles= window.innerWidth < 768 ? 1 : 3;
 
   // 3) Funciones de control
   function actualizarChevron() {

--- a/style2.css
+++ b/style2.css
@@ -299,15 +299,15 @@ body{
 }
 
 .serviciosCont.contenedor{
-    position: absolute;
     display: flex;
     align-items: center;
-    max-width: 50%;
+    width: 100%;
 }
 
 
 .servicios{
     display: flex;
+    flex-wrap: wrap;
     overflow: hidden;
     justify-content: space-between;
     align-content: space-between;
@@ -407,11 +407,7 @@ body{
 
 
 @media screen and (max-width: 768px) {
-    .serviciosCont.contenedor{
-        max-width: 100%;
-    }
     .servicios{
-        flex-direction: column;
         align-items: center;
     }
     .servicio{


### PR DESCRIPTION
## Summary
- Permite que el contenedor de servicios use todo el ancho disponible
- Habilita el salto de línea de tarjetas con `flex-wrap`
- Ajusta el carrusel para mostrar 1 o 3 elementos según el ancho de la ventana

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce3e25408329968cec299760e2bc